### PR TITLE
Allow `type` param to be a Function returning a boolean to match incoming action types

### DIFF
--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -167,7 +167,7 @@ export default function createLogic(logicOptions = {}) {
 
   return {
     name: typeToStrFns(name),
-    type: typeToStrFns(type),
+    type,
     cancelType: typeToStrFns(cancelType),
     latest,
     debounce,

--- a/src/logicWrapper.js
+++ b/src/logicWrapper.js
@@ -65,6 +65,9 @@ function matchesType(tStrArrRe, type) {
   if (typeof tStrArrRe === 'string') {
     return (tStrArrRe === type || tStrArrRe === '*');
   }
+  if (typeof tStrArrRe === 'function') {
+    return tStrArrRe(type) === true;
+  }
   if (Array.isArray(tStrArrRe)) {
     return tStrArrRe.some(x => matchesType(x, type));
   }

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -395,24 +395,21 @@ describe('createLogic', () => {
   describe('type given fn', () => {
     it('converts type to fn.toString()', () => {
       const fn = () => {};
-      fn.toString = () => 'myType';
       const logic = createLogic({
         type: fn
       });
-      expect(logic.type).toBe('myType');
+      expect(logic.type).toBe(fn);
     });
   });
 
   describe('type given array of fns', () => {
-    it('converts type to arr of fn.toString()', () => {
+    it('converts type to arr of fn', () => {
       const fn = () => {};
-      fn.toString = () => 'myType';
       const fn2 = () => {};
-      fn2.toString = () => 'myType2';
       const logic = createLogic({
         type: [fn, fn2]
       });
-      expect(logic.type).toEqual(['myType', 'myType2']);
+      expect(logic.type).toEqual([fn, fn2]);
     });
   });
 


### PR DESCRIPTION
Currently the `type` parameter to createLogic({ ... }) can be either a String, an Object, or a Function. However,  if it is a function it just calls toString() on the function rather than anything useful.

Given a function (or array of functions), the each function is converted to a string using fn.toString(). I don't see a good use for this form and there are no examples using this.

Why not allow the function form of this parameter to return a boolean of whether or not it matches the given action?

Example usage (contrived, since this one can be done with RegEx):

```
createLogic({
  type: actionType => actionType.length === 3
  ...
});
```

This would allow for more flexibility than just a RegEx and the current (fn.toString) implementation could still easily be accomplished through just doing:

```
createLogic({
  type: fn.toString()
  ...
});
```
