### PR TITLE
Make rxjs a direct dependency and document in installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,15 @@ These changes are not breaking but they are noteworthy since they prepare for th
 
 ## Usage
 
+redux-logic uses rxjs@5 under the covers and to prevent multiple copies (of different versions) from being installed, it is recommended to install rxjs first before redux-logic. That way you can use the same copy of rxjs elsewhere.
+
+If you are never using rxjs outside of redux-logic and don't plan to use Observables directly in your logic then you can skip the rxjs install and it will be installed as a redux-logic dependency. However if you think you might use Observables directly in the future (possibly creating Observables in your logic), it is still recommended to install rxjs separately first
+just to help ensure that only one copy will be in the project.
+
+The rxjs install below `npm install rxjs@^5` installs the lastest 5.x.x version of rxjs.
+
 ```bash
-npm install rxjs --save
+npm install rxjs@^5 --save  # optional see note above
 npm install redux-logic --save
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,9 +2,24 @@
 
 Contents:
 
+ - [Installation](#installation)
  - [Main usage](#main-usage)
  - [Execution phase hooks](#execution-phase-hooks---validate-transform-process) - [validate](#validate-hook), [transform](#transform-hook), [process](#process-hook)
  - [Advanced usage](#advanced-usage)
+
+## Installation
+
+redux-logic uses rxjs@5 under the covers and to prevent multiple copies (of different versions) from being installed, it is recommended to install rxjs first before redux-logic. That way you can use the same copy of rxjs elsewhere.
+
+If you are never using rxjs outside of redux-logic and don't plan to use Observables directly in your logic then you can skip the rxjs install and it will be installed as a redux-logic dependency. However if you think you might use Observables directly in the future (possibly creating Observables in your logic), it is still recommended to install rxjs separately first
+just to help ensure that only one copy will be in the project.
+
+The rxjs install below `npm install rxjs@^5` installs the lastest 5.x.x version of rxjs.
+
+```bash
+npm install rxjs@^5 --save  # optional see note above
+npm install redux-logic --save
+```
 
 ## Main usage
 

--- a/package.json
+++ b/package.json
@@ -78,11 +78,11 @@
   "dependencies": {
     "is-observable": "^0.2.0",
     "is-promise": "^2.1.0",
-    "loose-envify": "^1.2.0"
+    "loose-envify": "^1.2.0",
+    "rxjs": "^5.0.3"
   },
   "peerDependencies": {
-    "redux": "^3.5.2",
-    "rxjs": "^5.0.3"
+    "redux": "^3.5.2"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
@@ -126,7 +126,6 @@
     "nyc": "^8.3.0",
     "redux": "^3.5.2",
     "rimraf": "^2.3.4",
-    "rxjs": "^5.0.3",
     "webpack": "^1.9.6",
     "yarn": "^0.19.1"
   },


### PR DESCRIPTION
To simplify use where a developer only wants to use redux-logic and
doesn't plan to use observables directly, making rxjs a dependency
allows redux-logic to be installed w/o manually installing rxjs first.

It is still recommended to install rxjs first if Observables will
directly be used in the project, so that multiple copies are not
installed. A note was added to the readme.
