### PR TITLE
Export function to set 'createLogic' options globally

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,13 @@ Contents:
 
  - [Installation](#installation)
  - [Main usage](#main-usage)
- - [Execution phase hooks](#execution-phase-hooks---validate-transform-process) - [validate](#validate-hook), [transform](#transform-hook), [process](#process-hook)
+    - [createLogic](#createlogic)
+    - [configureLogic](#configurelogic)
+    - [createLogicMiddleware](#createlogicmiddleware)
+ - [Execution phase hooks](#execution-phase-hooks---validate-transform-process)
+    - [validate](#validate-hook)
+    - [transform](#transform-hook)
+    - [process](#process-hook)
  - [Advanced usage](#advanced-usage)
 
 ## Installation
@@ -22,9 +28,9 @@ npm install redux-logic --save
 ```
 
 ## Main usage
-
+### createLogic
 ```js
-import { createLogic, createLogicMiddleware } from 'redux-logic';
+import { createLogic } from 'redux-logic';
 
 /* returns a logic object that resembles the same structure of the
    input except that some defaults are applied and values were
@@ -103,6 +109,27 @@ const fooLogic = createLogic({
     done(); // only when performing multiple dispatches (done in signature)
   })
 });
+```
+
+### configureLogic
+```js
+import { configureLogic } from 'redux-logic';
+
+// globally configure ALL Logic instance defaults instead of overriding these
+// properties on each call to `createLogic`. These defaults will not be applied
+// to `Logic` instances that have already been created.
+//
+// specify all or a subset of the following properties:
+configureLogic({
+
+  // provide different default values than the package defaults.
+  warnTimeout: 10000,
+})
+```
+
+### createLogicMiddleware
+```js
+import { createLogicMiddleware } from 'redux-logic';
 
 const logicMiddleware = createLogicMiddleware(
   arrLogic, // array of logic items, no duplicate refs to same logic

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
-import createLogic from './createLogic';
+import createLogic, { configureLogic } from './createLogic';
 import createLogicMiddleware from './createLogicMiddleware';
 
 export {
+  configureLogic,
   createLogic,
   createLogicMiddleware
 };
 
 export default {
+  configureLogic,
   createLogic,
   createLogicMiddleware
 };

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import Rx from 'rxjs';
-import { createLogic, createLogicMiddleware } from '../src/index';
+import { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -35,6 +35,16 @@ describe('createLogic', () => {
         warnTimeout: 120000 // 120,000ms == 2 minutes
       });
       expect(fooLogic.warnTimeout).toBe(120000);
+    });
+
+    it('can be set globally', () => {
+      configureLogic({ warnTimeout: 0 });
+      const fooLogic = createLogic({
+        type: '*',
+      });
+      expect(fooLogic.warnTimeout).toBe(0);
+
+      configureLogic({ warnTimeout: 60000 }); // Reset to default to avoid polluting other tests.
     });
 
     it('errors if they try to set it as processOptions.warnTimeout', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,13 +1,22 @@
 import expect from 'expect';
-import mod, { createLogic, createLogicMiddleware } from '../src/index';
+import mod, { createLogic, createLogicMiddleware, configureLogic } from '../src/index';
 
 describe('index.js', () => {
+  it('should provide a configureLogic function', () => {
+    expect(configureLogic).toBeA(Function);
+  });
+
   it('should provide createLogic function', () => {
     expect(createLogic).toBeA(Function);
   });
 
   it('should provide createLogicMiddleware function', () => {
     expect(createLogicMiddleware).toBeA(Function);
+  });
+
+  it('should provide a default obj with configureLogic', () => {
+    expect(mod.configureLogic) // eslint-disable-line import/no-named-as-default-member
+      .toBeA(Function);
   });
 
   it('should provide a default obj with createLogic', () => {


### PR DESCRIPTION
Make a single call to the 'configureLogic' function to override the
redux-logic library defaults for the following options:

  warnTimeout
  latest
  debounce
  throttle

Closes #51