### PR TITLE
add support for Symbol primitives as types

### DIFF
--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -1,3 +1,4 @@
+import { stringifyType } from './utils';
 
 const allowedOptions = [
   'name',
@@ -188,7 +189,7 @@ export default function createLogic(logicOptions = {}) {
       typeof processOptions.dispatchMultiple !== 'undefined' &&
       warnTimeout !== 0) {
     // eslint-disable-next-line no-console
-    console.error(`warning: in logic for type(s): ${type} - dispatchMultiple is always true in next version. For non-ending logic, set warnTimeout to 0`);
+    console.error(`warning: in logic for type(s): ${stringifyType(type)} - dispatchMultiple is always true in next version. For non-ending logic, set warnTimeout to 0`);
   }
 
   // use process fn signature to determine some processOption defaults
@@ -203,7 +204,7 @@ export default function createLogic(logicOptions = {}) {
           !processOptions.dispatchMultiple
           && warnTimeout !== 0) {
         // eslint-disable-next-line no-console
-        console.error(`warning: in logic for type(s): ${type} - single-dispatch mode is deprecated, call done when finished dispatching. For non-ending logic, set warnTimeout: 0`);
+        console.error(`warning: in logic for type(s): ${stringifyType(type)} - single-dispatch mode is deprecated, call done when finished dispatching. For non-ending logic, set warnTimeout: 0`);
       }
       // nothing to do, defaults are fine
       break;

--- a/src/createLogicMiddleware.js
+++ b/src/createLogicMiddleware.js
@@ -7,7 +7,7 @@ import 'rxjs/add/operator/scan';
 import 'rxjs/add/operator/takeWhile';
 import 'rxjs/add/operator/toPromise';
 import wrapper from './logicWrapper';
-import { confirmProps } from './utils';
+import { confirmProps, stringifyType } from './utils';
 
 // confirm custom Rx build imports
 confirmProps(Observable.prototype, [
@@ -258,7 +258,7 @@ function naming(logic, idx) {
   if (logic.name) { return logic; }
   return {
     ...logic,
-    name: `L(${logic.type.toString()})-${idx}`
+    name: `L(${stringifyType(logic.type)})-${idx}`
   };
 }
 

--- a/src/logicWrapper.js
+++ b/src/logicWrapper.js
@@ -62,6 +62,9 @@ export default function logicWrapper(logic, store, deps, monitor$) {
 function matchesType(tStrArrRe, type) {
   /* istanbul ignore if  */
   if (!tStrArrRe) { return false; } // nothing matches none
+  if (typeof tStrArrRe === 'symbol') {
+    return (tStrArrRe === type);
+  }
   if (typeof tStrArrRe === 'string') {
     return (tStrArrRe === type || tStrArrRe === '*');
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,3 +7,12 @@ export function confirmProps(obj, arrProps, objName = '') {
     }
   });
 }
+
+// Symbols and Arrays containing Symbols cannot be interpolated in template strings,
+// they must be explicitly converted with toString()
+// eslint-disable-next-line import/prefer-default-export
+export function stringifyType(type) {
+  return Array.isArray(type) ?
+         type.map(type => type.toString()) :
+         type.toString();
+}

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,5 +1,5 @@
 import expect from 'expect';
-import { confirmProps } from '../src/utils';
+import { confirmProps, stringifyType } from '../src/utils';
 
 
 describe('confirmProps', () => {
@@ -40,4 +40,22 @@ describe('confirmProps', () => {
     expect(verify).toThrow('missing  property: b');
   });
 
+});
+
+describe('stringifyType', () => {
+  it('should stringify a single type of string|symbol|regex', () => {
+    [
+      ['FOO', 'FOO'],
+      [Symbol('BAR'), 'Symbol(BAR)'],
+      [/CAT/, '/CAT/']
+    ].forEach(([type, string]) => {
+      expect(stringifyType(type)).toEqual(string);
+    });
+  });
+
+  it('should stringify contents of an arr type of string|symbol|regex', () => {
+    const type = ['FOO', Symbol('BAR'), /CAT/];
+    const string = ['FOO', 'Symbol(BAR)', '/CAT/'];
+    expect(stringifyType(type)).toEqual(string);
+  });
 });


### PR DESCRIPTION
This patch adds support for Symbol primitives as types. This was desirable in my situation in order to use enums like so:
```js
// actions.js
import Enum from 'es6-enum'

export const actionTypes = new Enum(
  'CREATE_TIMER',
  'TOGGLE_TIMER',
  ...
)

//logic.js
...
import {actionTypes} from './actions'

const toggleTimerLogic = createLogic({
  type: actionTypes.TOGGLE_TIMER,
  ...
}) 
```
If there are no issues with this, I will ping again once I've updated the documentation and read through `/src` in case `matchesType` affects anything I may have missed. It is currently working properly for me under simple usage. 

@jeffbski many thanks for the wicked lib, it really helps cut down on a lot of tedious async boilerplate.