### PR TITLE
Prevent users from passing stringified undefined as type

### DIFF
--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -156,15 +156,19 @@ export default function createLogic(logicOptions = {}) {
   }
 
   const { name, type, cancelType,
-          warnTimeout = defaultOptions.warnTimeout,
-          latest = defaultOptions.latest,
-          debounce = defaultOptions.debounce,
-          throttle = defaultOptions.throttle,
-          validate, transform, process = emptyProcess,
-          processOptions = {} } = logicOptions;
+    warnTimeout = defaultOptions.warnTimeout,
+    latest = defaultOptions.latest,
+    debounce = defaultOptions.debounce,
+    throttle = defaultOptions.throttle,
+    validate, transform, process = emptyProcess,
+    processOptions = {} } = logicOptions;
 
   if (!type) {
     throw new Error('type is required, use \'*\' to match all actions');
+  }
+
+  if (type === 'undefined') {
+    throw new Error('type is a string "undefined", check the logicOptions type field for a stringified undefined value');
   }
 
   if (validate && transform) {
@@ -181,12 +185,12 @@ export default function createLogic(logicOptions = {}) {
   }
 
   const validateDefaulted = (!validate && !transform) ?
-        identityValidation :
-        validate;
+    identityValidation :
+    validate;
 
   if (NODE_ENV !== 'production' &&
-      typeof processOptions.dispatchMultiple !== 'undefined' &&
-      warnTimeout !== 0) {
+    typeof processOptions.dispatchMultiple !== 'undefined' &&
+    warnTimeout !== 0) {
     // eslint-disable-next-line no-console
     console.error(`warning: in logic for type(s): ${type} - dispatchMultiple is always true in next version. For non-ending logic, set warnTimeout to 0`);
   }
@@ -200,8 +204,8 @@ export default function createLogic(logicOptions = {}) {
       break;
     case 2: // process(deps, dispatch) - single dispatch (deprecated)
       if (NODE_ENV !== 'production' &&
-          !processOptions.dispatchMultiple
-          && warnTimeout !== 0) {
+        !processOptions.dispatchMultiple
+        && warnTimeout !== 0) {
         // eslint-disable-next-line no-console
         console.error(`warning: in logic for type(s): ${type} - single-dispatch mode is deprecated, call done when finished dispatching. For non-ending logic, set warnTimeout: 0`);
       }

--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -156,12 +156,12 @@ export default function createLogic(logicOptions = {}) {
   }
 
   const { name, type, cancelType,
-    warnTimeout = defaultOptions.warnTimeout,
-    latest = defaultOptions.latest,
-    debounce = defaultOptions.debounce,
-    throttle = defaultOptions.throttle,
-    validate, transform, process = emptyProcess,
-    processOptions = {} } = logicOptions;
+          warnTimeout = defaultOptions.warnTimeout,
+          latest = defaultOptions.latest,
+          debounce = defaultOptions.debounce,
+          throttle = defaultOptions.throttle,
+          validate, transform, process = emptyProcess,
+          processOptions = {} } = logicOptions;
 
   if (!type) {
     throw new Error('type is required, use \'*\' to match all actions');
@@ -185,12 +185,12 @@ export default function createLogic(logicOptions = {}) {
   }
 
   const validateDefaulted = (!validate && !transform) ?
-    identityValidation :
-    validate;
+        identityValidation :
+        validate;
 
   if (NODE_ENV !== 'production' &&
-    typeof processOptions.dispatchMultiple !== 'undefined' &&
-    warnTimeout !== 0) {
+      typeof processOptions.dispatchMultiple !== 'undefined' &&
+      warnTimeout !== 0) {
     // eslint-disable-next-line no-console
     console.error(`warning: in logic for type(s): ${type} - dispatchMultiple is always true in next version. For non-ending logic, set warnTimeout to 0`);
   }
@@ -204,8 +204,8 @@ export default function createLogic(logicOptions = {}) {
       break;
     case 2: // process(deps, dispatch) - single dispatch (deprecated)
       if (NODE_ENV !== 'production' &&
-        !processOptions.dispatchMultiple
-        && warnTimeout !== 0) {
+          !processOptions.dispatchMultiple
+          && warnTimeout !== 0) {
         // eslint-disable-next-line no-console
         console.error(`warning: in logic for type(s): ${type} - single-dispatch mode is deprecated, call done when finished dispatching. For non-ending logic, set warnTimeout: 0`);
       }

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -19,6 +19,14 @@ describe('createLogic', () => {
         createLogic({});
       }).toThrow(/type.*required/);
     });
+
+    it('throws type cannot be "undefined" error', () => {
+      expect(() => {
+        createLogic({
+          type: `${undefined}`
+        });
+      }).toThrow(/type.*undefined/);
+    });
   });
 
   describe('warnTimeout', () => {
@@ -392,7 +400,7 @@ describe('createLogic', () => {
 
   describe('name given fn', () => {
     it('converts name to fn.toString()', () => {
-      const fn = () => {};
+      const fn = () => { };
       fn.toString = () => 'myFn';
       const logic = createLogic({
         name: fn,
@@ -404,7 +412,7 @@ describe('createLogic', () => {
 
   describe('type given fn', () => {
     it('converts type to fn.toString()', () => {
-      const fn = () => {};
+      const fn = () => { };
       fn.toString = () => 'myType';
       const logic = createLogic({
         type: fn
@@ -415,9 +423,9 @@ describe('createLogic', () => {
 
   describe('type given array of fns', () => {
     it('converts type to arr of fn.toString()', () => {
-      const fn = () => {};
+      const fn = () => { };
       fn.toString = () => 'myType';
-      const fn2 = () => {};
+      const fn2 = () => { };
       fn2.toString = () => 'myType2';
       const logic = createLogic({
         type: [fn, fn2]

--- a/test/createLogic.spec.js
+++ b/test/createLogic.spec.js
@@ -400,7 +400,7 @@ describe('createLogic', () => {
 
   describe('name given fn', () => {
     it('converts name to fn.toString()', () => {
-      const fn = () => { };
+      const fn = () => {};
       fn.toString = () => 'myFn';
       const logic = createLogic({
         name: fn,
@@ -412,7 +412,7 @@ describe('createLogic', () => {
 
   describe('type given fn', () => {
     it('converts type to fn.toString()', () => {
-      const fn = () => { };
+      const fn = () => {};
       fn.toString = () => 'myType';
       const logic = createLogic({
         type: fn
@@ -423,9 +423,9 @@ describe('createLogic', () => {
 
   describe('type given array of fns', () => {
     it('converts type to arr of fn.toString()', () => {
-      const fn = () => { };
+      const fn = () => {};
       fn.toString = () => 'myType';
-      const fn2 = () => { };
+      const fn2 = () => {};
       fn2.toString = () => 'myType2';
       const logic = createLogic({
         type: [fn, fn2]


### PR DESCRIPTION
## Motivation

I was spending time debugging and figuring out why my redux-logic wasn't firing for a specific action type:

```js
const createFollowupLogic = createLogic({
  type: `${actions.responses.createFollowup}`,
  async process({ action, api }, dispatch, done) {
    // logic stuffs here
  },
});
```

However, I had a typo in my action name (I didn't realize so easily). This caused my action name to be:

```js
type: `${undefined}`
```

which gets evaluated as

```js
type: "undefined"
```

Currently, `redux-logic` only throws an error of the `type` is falsy telling the user that their type needs to have a value. This PR adds an extra convenience check to make sure the user didn't pass a stringified `undefined` value. Hopefully this will save someone else time when they are trying to get a specific logic working but they made a typo :).