### PR TITLE
support for redux@4.0.0+, additional tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3499,12 +3499,6 @@
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
-    "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg==",
-      "dev": true
-    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -5440,15 +5434,13 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
       "dev": true,
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "symbol-observable": "^1.2.0"
       },
       "dependencies": {
         "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "rxjs": "^5.0.3"
   },
   "peerDependencies": {
-    "redux": "^3.5.2"
+    "redux": ">=3.5.2"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
@@ -119,7 +119,7 @@
     "lodash": "^4.17.10",
     "mocha": "^5.2.0",
     "nyc": "^13.0.0",
-    "redux": "^3.5.2",
+    "redux": ">=3.5.2",
     "rimraf": "^2.3.4",
     "webpack": "^1.9.6"
   },

--- a/test/createLogicMiddleware-many-logic.spec.js
+++ b/test/createLogicMiddleware-many-logic.spec.js
@@ -4,7 +4,7 @@ import { applyMiddleware, createStore } from 'redux';
 import { createLogic, createLogicMiddleware } from '../src/index';
 
 describe('createLogicMiddleware-many-logic', () => {
-  describe('createLogicMiddleware()', () => {
+  describe('with validate and process', () => {
     const NUM_LOGICS = 200;
     let mw;
     let store;
@@ -48,4 +48,80 @@ describe('createLogicMiddleware-many-logic', () => {
       expect(store.getState()).toEqual({ validates: NUM_LOGICS, processes: NUM_LOGICS });
     });
   });
+
+  describe('with validate', () => {
+    const NUM_LOGICS = 200;
+    let mw;
+    let store;
+
+    beforeEach(() => {
+      const arrLogic = range(0, NUM_LOGICS).map(() => createLogic({
+        type: 'foo',
+        validate({ action }, allow) {
+          allow({
+            ...action,
+            validates: action.validates + 1
+          });
+        }
+      }));
+      mw = createLogicMiddleware(arrLogic);
+      const reducer = (state = { validates: 0, processes: 0 }, action) => {
+        switch (action.type) {
+        case 'foo' :
+          return {
+            ...state,
+            validates: state.validates + action.validates
+          };
+        default:
+          return state;
+        }
+      };
+      store = createStore(reducer, undefined, applyMiddleware(mw));
+      store.dispatch({ type: 'foo', validates: 0 });
+    });
+
+    it('expect state to be updated', () => {
+      expect(store.getState()).toEqual({ validates: NUM_LOGICS, processes: 0 });
+    });
+  });
+
+  describe('with process', () => {
+    const NUM_LOGICS = 200;
+    let mw;
+    let store;
+
+    beforeEach(() => {
+      const arrLogic = range(0, NUM_LOGICS).map(() => createLogic({
+        type: 'foo',
+        process({ action }, dispatch, done) {
+          dispatch({ type: 'foo-success' });
+          done();
+        }
+      }));
+      mw = createLogicMiddleware(arrLogic);
+      const reducer = (state = { validates: 0, processes: 0 }, action) => {
+        switch (action.type) {
+        case 'foo' :
+          return {
+            ...state,
+            validates: state.validates + action.validates
+          };
+        case 'foo-success' :
+          return {
+            ...state,
+            processes: state.processes + 1
+          };
+        default:
+          return state;
+        }
+      };
+      store = createStore(reducer, undefined, applyMiddleware(mw));
+      store.dispatch({ type: 'foo', validates: 0 });
+    });
+
+    it('expect state to be updated', () => {
+      expect(store.getState()).toEqual({ validates: 0, processes: NUM_LOGICS });
+    });
+  });
+
 });


### PR DESCRIPTION
redux-logic will work fine with redux@4.0.0 as well as the
older 3.5.x versions.

peer dependency and dev dependency to support >=3.5.2 allowing
the use of either.

Added additional tests to test different combination of hooks.