### PR TITLE
Fix Typescript Definitions with strictNullChecks

### DIFF
--- a/definitions/action.d.ts
+++ b/definitions/action.d.ts
@@ -13,6 +13,8 @@
  * -------------------------------------------------------------------------
  */
 
+import { Object } from './utilities';
+
 //
 // ACTION
 //
@@ -27,15 +29,15 @@
 /** Action as an agrument */
 export type ArgumentAction<
   Type extends string = string,
-  Payload extends object = undefined,
-  Meta extends object = undefined
+  Payload extends Object = undefined,
+  Meta extends Object = undefined
 > = ActionBasis<Type> & Partial<Action<string, object, object>>;
 
 /** all different types of Action */
 export type Action<
   Type extends string = string,
-  Payload extends object = undefined,
-  Meta extends object = undefined
+  Payload extends Object = undefined,
+  Meta extends Object = undefined
 > =
   | ErroneousAction<Type, Meta>
   | (StandardAction<Type, Payload, Meta> & { error?: false });
@@ -43,14 +45,14 @@ export type Action<
 /** Action without any error */
 export type StandardAction<
   Type extends string = string,
-  Payload extends object = undefined,
-  Meta extends object = undefined
+  Payload extends Object = undefined,
+  Meta extends Object = undefined
 > = ActionBasis<Type> & PayloadBasis<Payload> & MetaBasis<Meta>;
 
 /** Action with an Error */
 export type ErroneousAction<
   Type extends string = string,
-  Meta extends object = undefined
+  Meta extends Object = undefined
 > = ActionBasis<Type> & PayloadBasis<Error> & MetaBasis<Meta> & { error: true };
 
 /* ----- Auxiliary Types ----- */
@@ -62,11 +64,11 @@ export interface ActionBasis<Type extends string = string> {
 
 /** return an interface with payload only if it presents */
 export type PayloadBasis<
-  Payload extends object = undefined
+  Payload extends Object = undefined
 > = Payload extends undefined ? {} : { payload: Payload };
 
 /** return an interface with meta only if it presents */
-export type MetaBasis<Meta extends object = undefined> = Meta extends undefined
+export type MetaBasis<Meta extends Object = undefined> = Meta extends undefined
   ? {}
   : { meta: Meta };
 

--- a/definitions/index.d.ts
+++ b/definitions/index.d.ts
@@ -13,7 +13,6 @@
  * -------------------------------------------------------------------------
  */
 
-export * from './action';
-export * from './logic';
-export * from './middleware';
-export * from './utilities';
+export { Action, ErroneousAction, StandardAction } from './action';
+export { configureLogic, createLogic, Logic } from './logic';
+export { createLogicMiddleware, LogicMiddleware } from './middleware';

--- a/definitions/logic.d.ts
+++ b/definitions/logic.d.ts
@@ -17,14 +17,8 @@ import { Subject } from 'rxjs';
 
 import { Middleware } from 'redux';
 
-import {
-  ArgumentAction,
-  Action,
-  ActionBasis,
-  Override,
-  StandardAction
-} from './';
-import { Context } from 'vm';
+import { ArgumentAction, Action, ActionBasis, StandardAction } from './action';
+import { Object, Override } from './utilities';
 
 //
 // LOGIC
@@ -41,10 +35,10 @@ import { Context } from 'vm';
 
 export type Logic<
   State extends object = {},
-  Payload extends object = undefined,
-  Meta extends object = undefined,
+  Payload extends Object = undefined,
+  Meta extends Object = undefined,
   Dependency extends object = {},
-  Context extends object = undefined,
+  Context extends Object = undefined,
   Type extends string = string
 > = Override<
   CreateLogic.Config<
@@ -69,10 +63,10 @@ export interface CreateLogic {
   // full createLogic declaration
   <
     State extends object,
-    Payload extends object = undefined,
-    Meta extends object = undefined,
+    Payload extends Object = undefined,
+    Meta extends Object = undefined,
     Dependency extends object = {},
-    Context extends object = undefined,
+    Context extends Object = undefined,
     Type extends string = string
   >(
     config: CreateLogic.Config<
@@ -87,8 +81,8 @@ export interface CreateLogic {
   // createLogic wihout context
   <
     State extends object,
-    Payload extends object = undefined,
-    Meta extends object = undefined,
+    Payload extends Object = undefined,
+    Meta extends Object = undefined,
     Dependency extends object = {},
     Type extends string = string
   >(
@@ -105,7 +99,7 @@ export interface CreateLogic {
   <
     State extends object,
     Dependency extends object = {},
-    Context extends object = undefined,
+    Context extends Object = undefined,
     Type extends string = string
   >(
     config: CreateLogic.Config<State, Action<Type>, Dependency, Context, Type>
@@ -131,7 +125,7 @@ export namespace CreateLogic {
     State extends object,
     Action extends StandardAction,
     Dependency extends object,
-    Context extends object,
+    Context extends Object,
     Type extends string
   > = Config.Base<State, Action, Type> &
     (
@@ -154,10 +148,10 @@ export namespace CreateLogic {
 
     export type TypeMatcher<
       Type extends string | symbol,
-      Payload extends object
+      Payload extends Object
     > = PrimitiveType<Type, Payload> | PrimitiveType<Type, Payload>[];
 
-    export type Pass<Action extends ActionBasis, Context extends object> = (
+    export type Pass<Action extends ActionBasis, Context extends Object> = (
       action: ArgumentAction &
         (Context extends undefined
           ? {}
@@ -189,7 +183,7 @@ export namespace CreateLogic {
       State,
       Action extends ActionBasis,
       Dependency extends object,
-      Context extends object
+      Context extends Object
     > {
       validate?: Validate.Hook<State, Action, Dependency, Context>;
     }
@@ -199,7 +193,7 @@ export namespace CreateLogic {
         State,
         Action extends ActionBasis,
         Dependency extends object,
-        Context extends object = undefined
+        Context extends Object = undefined
       > = (
         depObj: DepObj<State, Action, Dependency>,
         allow: Pass<Action, Context>,
@@ -215,7 +209,7 @@ export namespace CreateLogic {
       State,
       Action extends ActionBasis,
       Dependency extends object,
-      Context extends object
+      Context extends Object
     > {
       transform?: Transform.Hook<State, Action, Dependency, Context>;
     }
@@ -225,7 +219,7 @@ export namespace CreateLogic {
         State,
         Action extends ActionBasis,
         Dependency extends object,
-        Context extends object = undefined
+        Context extends Object = undefined
       > = (
         depObj: DepObj<State, Action, Dependency>,
         next: Pass<Action, Context>
@@ -237,7 +231,7 @@ export namespace CreateLogic {
     /* ----- process ----- */
 
     type ActionCreator<
-      InputPayload extends object
+      InputPayload extends Object
     > = InputPayload extends undefined
       ? (payload?: InputPayload) => StandardAction<string, any>
       : (InputPayload extends Error
@@ -254,7 +248,7 @@ export namespace CreateLogic {
       State extends object,
       Action extends StandardAction<string>,
       Dependency extends object,
-      Context extends object = undefined
+      Context extends Object = undefined
     > {
       processOptions?: Process.Options<Action>;
       process?:
@@ -274,7 +268,7 @@ export namespace CreateLogic {
         State extends object,
         Action extends StandardAction,
         Dependency extends object,
-        Context extends object = undefined
+        Context extends Object = undefined
       > = Config.DepObj<State, Action, Dependency> & {
         cancelled$: Subject<void>;
         ctx: Context;
@@ -284,14 +278,14 @@ export namespace CreateLogic {
         State extends object,
         Action extends StandardAction,
         Dependency extends object,
-        Context extends object = undefined
+        Context extends Object = undefined
       > = (depObj: Process.DepObj<State, Action, Dependency, Context>) => void;
 
       export type AdvancedHook<
         State extends object,
         Action extends StandardAction,
         Dependency extends object,
-        Context extends object = undefined
+        Context extends Object = undefined
       > = ((
         depObj: Process.DepObj<State, Action, Dependency, Context>,
         dispatch: (action: ArgumentAction) => void,

--- a/definitions/middleware.d.ts
+++ b/definitions/middleware.d.ts
@@ -17,7 +17,9 @@ import { Subject } from 'rxjs';
 
 import { Middleware } from 'redux';
 
-import { Action, ArgumentAction, Logic } from './';
+import { Action, ArgumentAction } from './action';
+import { Logic } from './logic';
+import { Object } from './utilities';
 
 //
 // MIDDLEWARE
@@ -26,7 +28,7 @@ import { Action, ArgumentAction, Logic } from './';
 interface LogicMiddleware<
   State extends object = {},
   Dependency extends object = {},
-  Context extends object = undefined,
+  Context extends Object = undefined,
   Type extends string = string
 > extends Middleware {
   (store: CreateLogicMiddleware.Store<State>): CreateLogicMiddleware.Next;
@@ -73,7 +75,7 @@ interface LogicMiddleware<
 export function createLogicMiddleware<
   State extends object = {},
   Dependency extends object = {},
-  Context extends object = undefined,
+  Context extends Object = undefined,
   Type extends string = string
 >(
   logics?: Logic<State, any, any, Dependency, Context, Type>[],

--- a/definitions/utilities.d.ts
+++ b/definitions/utilities.d.ts
@@ -21,3 +21,6 @@
 export type Override<A, B> = {
   [K in keyof A]: K extends keyof B ? B[K] : A[K]
 };
+
+/** a simple helper type for accepting undfined */
+export type Object = object | undefined;

--- a/test/typecheck.action.ts
+++ b/test/typecheck.action.ts
@@ -13,7 +13,7 @@
  * -------------------------------------------------------------------------
  */
 
-import { Action, ErroneousAction, StandardAction } from '../definitions';
+import { Action, ErroneousAction, StandardAction } from '../definitions/action';
 
 //
 // Action Type
@@ -143,7 +143,7 @@ interface TestMeta {
   let action: Action;
 
   {
-    const test: boolean = action.error;
+    const test: boolean | undefined = action.error;
   }
 
   if (action.error === true) {
@@ -159,7 +159,7 @@ interface TestMeta {
   let action: Action<TestType, TestPayload, TestMeta>;
 
   {
-    const test: boolean = action.error;
+    const test: boolean | undefined = action.error;
   }
 
   if (action.error === true) {

--- a/test/typecheck.createLogic.ts
+++ b/test/typecheck.createLogic.ts
@@ -16,7 +16,7 @@
 import { configureLogic, createLogic } from '../';
 
 import { ErroneousAction, StandardAction } from '../';
-import { ActionBasis, MetaBasis, PayloadBasis } from '../';
+import { ActionBasis, MetaBasis, PayloadBasis } from '../definitions/action';
 
 import { Dependency, Meta, Payload, State } from './typecheck';
 

--- a/test/typecheck.middleware.ts
+++ b/test/typecheck.middleware.ts
@@ -17,7 +17,8 @@ import { Observable, Subject } from 'rxjs';
 
 import { createLogicMiddleware } from '../';
 
-import { Action, ArgumentAction, Logic } from '../';
+import { Action, ArgumentAction } from '../definitions/action';
+import { Logic } from '../definitions/logic';
 import { Payload, Meta } from './typecheck';
 
 //
@@ -48,10 +49,7 @@ let logicArray: Logic[];
   }
 
   {
-    let next: (action?: ArgumentAction) => Action;
-
-    const monArr = [];
-    let monitor: Subject<{
+    type Message = {
       action?:
         | 'op'
         | 'top'
@@ -69,8 +67,11 @@ let logicArray: Logic[];
       nextAction?: Action;
       shouldProcess?: boolean;
       dispAction?: Action;
-    }> =
-      middleware.monitor$;
+    };
+    let next: (action?: ArgumentAction) => Action;
+
+    const monArr: Message[] = [];
+    let monitor: Subject<Message> = middleware.monitor$;
     monitor.subscribe(x => monArr.push(x));
 
     const action = { type: 'type' };


### PR DESCRIPTION
The current definition emits error if `strictNullChecks` is on. This PR fix the issue and resolve #115.