### PR TITLE
check if process is available or runs in browser environment

### DIFF
--- a/src/createLogic.js
+++ b/src/createLogic.js
@@ -21,7 +21,7 @@ const allowedProcessOptions = [
   'failType',
 ];
 
-const NODE_ENV = process.env.NODE_ENV;
+const NODE_ENV = (process && process.env && process.env.NODE_ENV) ? process.env.NODE_ENV : '';
 
 const defaultOptions = {
   warnTimeout: 60000,


### PR DESCRIPTION

If redux-logic runs in browser environment this can create errors and the application fails.
Added a check if the process.env.NODE_ENV is available