### PR TITLE
Derive types for transform/process/validate hooks

### DIFF
--- a/test/typecheck.createLogic.ts
+++ b/test/typecheck.createLogic.ts
@@ -280,6 +280,33 @@ import { Dependency, Meta, Payload, State } from './typecheck';
   });
 }
 
+{
+  interface ActionCreator<P> {
+    (payload: P): { type: string; payload: P };
+    toString(): string;
+  }
+  let fooAction: ActionCreator<{ foo: number }>;
+  const logic1 = createLogic({
+    type: fooAction,
+    validate({action}) {
+      action.payload.foo.toFixed();
+    },
+  });
+  const logic2 = createLogic({
+    type: fooAction,
+    process({ action }) {
+      action.payload.foo.toExponential();
+    },
+  });
+  const logic3 = createLogic({
+    type: fooAction,
+    process({ action }, dispatch, done) {
+      action.payload.foo.toExponential();
+    },
+  })
+}
+
+
 //
 // EXPECT ERROR
 //

--- a/test/typecheck.createLogic.ts
+++ b/test/typecheck.createLogic.ts
@@ -182,7 +182,7 @@ import { Dependency, Meta, Payload, State } from './typecheck';
       dispatchReturn: true,
       successType: 'successType'
     },
-    process({ getState, action, cancelled$ }): void {
+    process({ getState, action, cancelled$ }: { getState: any, action: any, cancelled$: any }): void {
       let state: State = getState();
       let expectedAction:
         | (StandardAction<'type'>)
@@ -202,7 +202,7 @@ import { Dependency, Meta, Payload, State } from './typecheck';
       dispatchReturn: true,
       successType: (payload: Payload) => ({ type: 'successType' })
     },
-    process({ getState, action, cancelled$ }) {
+    process({ getState, action, cancelled$ }: { getState: any, action: any, cancelled$: any }) {
       let state: State = getState();
       let expectedAction:
         | (ActionBasis<'type'> & PayloadBasis<Payload> & MetaBasis<Meta>)
@@ -218,7 +218,7 @@ import { Dependency, Meta, Payload, State } from './typecheck';
       dispatchReturn: true,
       dispatchMultiple: false
     },
-    process(depObj) {
+    process(depObj: any) {
       let dep: Dependency = depObj;
       let state: State = depObj.getState();
       let expectedAction: (ActionBasis<'type'>) | ErroneousAction<'type'> =

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "noEmit": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitUseStrict": false,
     "noLib": false,
     "noResolve": false,


### PR DESCRIPTION
When the `type` for `createLogic` is an action creator, we can see what it's returning and derive the type of the action for the hooks later.