### PR TITLE
Propagate error stacktrace in monitor

### DIFF
--- a/src/createLogicMiddleware.js
+++ b/src/createLogicMiddleware.js
@@ -221,8 +221,7 @@ function applyLogic(arrLogic, store, next, sub, actionIn$, deps,
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('error in mw dispatch or next call, probably in middlware/reducer/render fn:', err);
-      const msg = (err && err.message) ? err.message : err;
-      monitor$.next({ action, err: msg, op: 'nextError' });
+      monitor$.next({ action, err, op: 'nextError' });
     }
     // at this point, action is the transformed action, not original
     monitor$.next({ nextAction: action, op: 'bottom' });

--- a/test/createLogicMiddleware-integrated.spec.js
+++ b/test/createLogicMiddleware-integrated.spec.js
@@ -69,7 +69,7 @@ describe('createLogicMiddleware-integration', () => {
           op: 'dispatch' },
         { action: { type: 'BAD' }, op: 'top' },
         { action: { type: 'BAD' },
-          err: 'something bad happened',
+          err: new Error('something bad happened'),
           op: 'nextError' },
         { nextAction: { type: 'BAD' }, op: 'bottom' },
         { action: { type: 'FOO' }, name: 'L(FOO)-0', op: 'end' }
@@ -137,7 +137,7 @@ describe('createLogicMiddleware-integration', () => {
           shouldProcess: true,
           op: 'next' },
         { action: { type: 'BAD' },
-          err: 'another bad thing',
+          err: new Error('another bad thing'),
           op: 'nextError' },
         { nextAction: { type: 'BAD' }, op: 'bottom' },
         { action: { type: 'BAD' }, name: 'L(BAD)-0', op: 'end' }


### PR DESCRIPTION
Wouldn't it be more informative to the advanced user to receive whatever was thrown (especially if it's an error object)?