### PR TITLE
fix: dispatch return argument action type  and not void

### DIFF
--- a/definitions/logic.d.ts
+++ b/definitions/logic.d.ts
@@ -290,7 +290,7 @@ export namespace CreateLogic {
         Context extends Object = undefined
       > = ((
         depObj: Process.DepObj<State, Action, Dependency, Context>,
-        dispatch: (action: ArgumentAction) => void,
+        dispatch: <T extends ArgumentAction>(action: T) => T,
         done: () => void
       ) => void);
     }


### PR DESCRIPTION
As you can see in redux definitions file, Dispatch return value and not void,
the value should be the returned type of the action argument that passed to dispatch function.

reference:
https://github.com/reduxjs/redux/blob/f6b8b53e68713eab5a46957525c693902c091611/index.d.ts#L124-L126
